### PR TITLE
Bugfix: 023 bug member not delete correctly

### DIFF
--- a/backend/src/main/java/com/nycu/ce/ciphergame/backend/dto/member/MemberResponse.java
+++ b/backend/src/main/java/com/nycu/ce/ciphergame/backend/dto/member/MemberResponse.java
@@ -1,5 +1,6 @@
 package com.nycu.ce.ciphergame.backend.dto.member;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import lombok.AllArgsConstructor;
@@ -15,4 +16,5 @@ public class MemberResponse {
 
     private UUID userId;
     private String username;
+    private LocalDateTime joinAt;
 }

--- a/backend/src/main/java/com/nycu/ce/ciphergame/backend/mapper/MemberMapper.java
+++ b/backend/src/main/java/com/nycu/ce/ciphergame/backend/mapper/MemberMapper.java
@@ -15,6 +15,7 @@ public class MemberMapper {
         return MemberResponse.builder()
                 .userId(member.getUser().getId())
                 .username(member.getUser().getUsername())
+                .joinAt(member.getJoinedAt())
                 .build();
     }
 

--- a/backend/src/main/java/com/nycu/ce/ciphergame/backend/repository/MemberRepository.java
+++ b/backend/src/main/java/com/nycu/ce/ciphergame/backend/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.nycu.ce.ciphergame.backend.repository;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,5 +32,7 @@ public interface MemberRepository extends JpaRepository<Member, MemberId> {
     List<User> findAllUsers(@Param("groupId") UUID groupId);
 
     long countByIdIn(List<MemberId> ids);
+
+    Set<Member> findAllByIdIn(Set<MemberId> ids);
 
 }

--- a/backend/src/main/java/com/nycu/ce/ciphergame/backend/service/me/MyGroupService.java
+++ b/backend/src/main/java/com/nycu/ce/ciphergame/backend/service/me/MyGroupService.java
@@ -44,7 +44,7 @@ public class MyGroupService {
         Member me = new Member(user, group);
 
         // Step 2: Add members to group
-        memberService.addAllMembers(group.getMembers(), Set.of(me));
+        memberService.addAllMembers(Set.of(me));
         return group;
     }
 


### PR DESCRIPTION
## Cause
The original function try to filter those targeted members in group and only delete them. However, using .filter actually filter out every thing since the member objects in two different lists are consider different.

Also, the filter is unnecessary since the target member is query from database with `memberId`, which guarantees the existence of those members

## Fix
Delete target members without filtering