### PR TITLE
Pull Request: Add `GET /deks` and `POST /deks` Endpoints to DekController

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ BACKEND_PASSWORD=backend123
 BACKEND_DB=app
 BACKEND_DB_URL=jdbc:postgresql://db:5432/app
 
+# dev user credentials (used in scripts/init-db.sh)
+DEK_USER=dek
+DEK_PASSWORD=dek123
+DEK_DB=app
+DEK_DB_URL=jdbc:postgresql://db:5432/app
+
 # jwt
 JWT_ISSUER_URI=http://auth-server:8081
 JWT_SECRET=EPD7cX81NK6v7UOyMN4WElbWJBpCLqUU

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ COMPOSE_DEV=docker-compose.dev.yml
 
 COMPOSE_FRONTEND_DEV=docker-compose.frontend.dev.yml
 COMPOSE_BACKEND_DEV=docker-compose.backend.dev.yml
+COMPOSE_DEK_DEV=docker-compose.dek.dev.yml
 COMPOSE_AUTH_DEV=docker-compose.auth.dev.yml
 COMPOSE_KMS_DEV=docker-compose.kms.dev.yml
 
@@ -27,6 +28,10 @@ dev-backend:
 	@echo "🔧 Starting backend development environment..."
 	docker-compose -f $(COMPOSE_BASE) -f $(COMPOSE_BACKEND_DEV) up --build -d
 
+dev-dek:
+	@echo "🔧 Starting dek development environment..."
+	docker-compose -f $(COMPOSE_BASE) -f $(COMPOSE_DEK_DEV) up --build -d
+
 dev-auth:
 	@echo "🔧 Starting auth development environment..."
 	docker-compose -f $(COMPOSE_BASE) -f $(COMPOSE_AUTH_DEV) up --build -d
@@ -44,6 +49,10 @@ dev-frontend-init: ## Start frontend dev environment and initialize DB roles
 
 dev-backend-init: ## Start backend dev environment and initialize DB roles
 	make dev-backend
+	make init-db MODE=development
+
+dev-dek-init: ## Start backend dev environment and initialize DB roles
+	make dev-dek
 	make init-db MODE=development
 
 dev-auth-init: ## Start auth dev environment and initialize DB roles
@@ -93,8 +102,12 @@ clean: ## Stop all containers and remove volumes
 init-spring: ## Initialize Spring Boot applications
 	@echo "🔧 Initializing backend Spring Boot application..."
 	cd backend && ./mvnw clean install -Dmaven.test.skip=true
+
 	@echo "🔧 Initializing auth Spring Boot application..."
 	cd auth && ./mvnw clean install -Dmaven.test.skip=true
+
+	@echo "🔧 Initializing dek Spring Boot application..."
+	cd dek && ./mvnw clean install -Dmaven.test.skip=true
 
 # ---------------------------
 # 🔐 DB Init (Post-Start SQL Setup)

--- a/dek/.dockerignore
+++ b/dek/.dockerignore
@@ -1,0 +1,7 @@
+*.class
+*.log
+.env
+.DS_Store
+.idea
+.vscode
+Dockerfile

--- a/dek/.gitattributes
+++ b/dek/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/dek/.gitignore
+++ b/dek/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/dek/.mvn/wrapper/maven-wrapper.properties
+++ b/dek/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/dek/Dockerfile
+++ b/dek/Dockerfile
@@ -1,0 +1,18 @@
+# backend/Dockerfile
+
+FROM openjdk:17-jdk-slim
+
+# Metadata
+LABEL maintainer="a313706026.mg13@nycu.edu.tw"
+
+# Set working directory
+WORKDIR /app
+
+# Copy build artifact (assuming using Maven or Gradle)
+COPY ./target/*.jar ./app.jar
+
+# Expose Spring Boot default port
+EXPOSE 8080
+
+# Run the app
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/dek/mvnw
+++ b/dek/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/dek/mvnw.cmd
+++ b/dek/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/dek/pom.xml
+++ b/dek/pom.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.nycu.ce.ciphergame</groupId>
+    <artifactId>dek</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>dek</name>
+    <description>Demo project for Spring Boot</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
+    </properties>
+
+    <dependencies>
+        <!-- Core Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+
+        <!-- DB -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
+        <!-- Lombok + MapStruct -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- OpenAPI / Swagger -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
+        <!-- Java Time (e.g., LocalDateTime) support -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- Utils -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/DekApplication.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/DekApplication.java
@@ -1,0 +1,13 @@
+package com.nycu.ce.ciphergame.dek;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DekApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DekApplication.class, args);
+	}
+
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/controller/DekController.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/controller/DekController.java
@@ -1,0 +1,59 @@
+package com.nycu.ce.ciphergame.dek.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.nycu.ce.ciphergame.dek.dto.DekQuery;
+import com.nycu.ce.ciphergame.dek.dto.DekRequest;
+import com.nycu.ce.ciphergame.dek.dto.DekResponse;
+import com.nycu.ce.ciphergame.dek.entity.Dek;
+import com.nycu.ce.ciphergame.dek.entity.id.DekId;
+import com.nycu.ce.ciphergame.dek.entity.id.UserId;
+import com.nycu.ce.ciphergame.dek.mapper.DekMapper;
+import com.nycu.ce.ciphergame.dek.service.DekService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/deks")
+public class DekController {
+
+    @Autowired
+    private DekService dekService;
+
+    @Autowired
+    private DekMapper dekMapper;
+
+    @PostMapping
+    public ResponseEntity<List<DekResponse>> storeDeks(
+            @Valid @RequestBody List<DekRequest> requests
+    ) {
+        List<Dek> newDeks = dekService.storeDeks(dekMapper.toEntity(requests));
+        return ResponseEntity.ok(dekMapper.toDTO(newDeks));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<DekResponse>> getDeks(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @ModelAttribute DekQuery queries
+    ) {
+        UserId myId = UserId.fromString(jwt.getSubject());
+        List<Dek> deks = dekService.getDeks(
+                myId,
+                queries.getDekIds().stream()
+                        .map(DekId::fromUUID)
+                        .collect(Collectors.toList()));
+        return ResponseEntity.ok(dekMapper.toDTO(deks));
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/dto/DekQuery.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/dto/DekQuery.java
@@ -1,0 +1,21 @@
+package com.nycu.ce.ciphergame.dek.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DekQuery {
+
+    @Size(max = 100, message = "At most 100 dekIds can be queried at a time")
+    @NotNull(message = "At least one dekId must be provided")
+    List<UUID> dekIds = new ArrayList<>();
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/dto/DekRequest.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/dto/DekRequest.java
@@ -1,0 +1,21 @@
+package com.nycu.ce.ciphergame.dek.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DekRequest {
+
+    @NotNull(message = "ownerId must not be empty")
+    private UUID ownerId;
+
+    @NotBlank(message = "dek must not be empty")
+    private String dek;
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/dto/DekResponse.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/dto/DekResponse.java
@@ -1,0 +1,14 @@
+package com.nycu.ce.ciphergame.dek.dto;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DekResponse {
+
+    private UUID id;
+    private String dek;
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/entity/Dek.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/entity/Dek.java
@@ -1,0 +1,47 @@
+package com.nycu.ce.ciphergame.dek.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+@Entity
+@Table(name = "encrypted_deks")
+public class Dek {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(name = "owner_id")
+    private UUID ownerId;
+
+    @Column(name = "cmk_version")
+    private int cmkVersion;
+
+    @Column(name = "encrypted_dek")
+    private String dek;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.cmkVersion = 1;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Dek() {
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/entity/id/DekId.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/entity/id/DekId.java
@@ -1,0 +1,35 @@
+package com.nycu.ce.ciphergame.dek.entity.id;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotNull;
+
+@Embeddable
+public record DekId(
+        @NotNull
+        UUID value
+        ) implements Serializable {
+
+    public static DekId generate() {
+        return new DekId(UUID.randomUUID());
+    }
+
+    public static DekId fromString(String str) {
+        return new DekId(UUID.fromString(str));
+    }
+
+    @Override
+    public String toString() {
+        return value != null ? value.toString() : "null";
+    }
+
+    public static DekId fromUUID(UUID id) {
+        return new DekId(id);
+    }
+
+    public UUID toUUID() {
+        return value;
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/entity/id/UserId.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/entity/id/UserId.java
@@ -1,0 +1,35 @@
+package com.nycu.ce.ciphergame.dek.entity.id;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.NotNull;
+
+@Embeddable
+public record UserId(
+        @NotNull
+        UUID value
+        ) implements Serializable {
+
+    public static UserId generate() {
+        return new UserId(UUID.randomUUID());
+    }
+
+    public static UserId fromString(String str) {
+        return new UserId(UUID.fromString(str));
+    }
+
+    @Override
+    public String toString() {
+        return value != null ? value.toString() : "null";
+    }
+
+    public static UserId fromUUID(UUID id) {
+        return new UserId(id);
+    }
+
+    public UUID toUUID() {
+        return value;
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/mapper/DekMapper.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/mapper/DekMapper.java
@@ -1,0 +1,40 @@
+package com.nycu.ce.ciphergame.dek.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.nycu.ce.ciphergame.dek.dto.DekRequest;
+import com.nycu.ce.ciphergame.dek.dto.DekResponse;
+import com.nycu.ce.ciphergame.dek.entity.Dek;
+
+@Component
+public class DekMapper {
+
+    public Dek toEntity(DekRequest dto) {
+        return Dek.builder()
+                .ownerId(dto.getOwnerId())
+                .dek(dto.getDek())
+                .build();
+    }
+
+    public List<Dek> toEntity(List<DekRequest> dtos) {
+        return dtos.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList());
+    }
+
+    public DekResponse toDTO(Dek entity) {
+        return DekResponse.builder()
+                .id(entity.getId())
+                .dek(entity.getDek())
+                .build();
+    }
+
+    public List<DekResponse> toDTO(List<Dek> entities) {
+        return entities.stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/repository/DekRepository.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/repository/DekRepository.java
@@ -1,0 +1,22 @@
+package com.nycu.ce.ciphergame.dek.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.nycu.ce.ciphergame.dek.entity.Dek;
+
+@Repository
+public interface DekRepository extends JpaRepository<Dek, UUID> {
+
+    @Query("""
+    SELECT d
+    FROM Dek d
+    WHERE d.ownerId = :ownerId
+    AND d.id IN :dekIds
+""")
+    List<Dek> findAllOwnerIdAndIdIn(UUID ownerId, List<UUID> dekIds);
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/security/SecurityConfig.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/security/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.nycu.ce.ciphergame.dek.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+// import com.nycu.ce.ciphergame.dek.rls.RlsSessionFilter;
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    // @Autowired
+    // private RlsSessionFilter rlsSessionFilter;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                .requestMatchers(
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/v3/api-docs/**"
+                ).permitAll()
+                .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(Customizer.withDefaults())
+                );
+        // .addFilterAfter(rlsSessionFilter, BearerTokenAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/service/DekService.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/service/DekService.java
@@ -1,0 +1,33 @@
+package com.nycu.ce.ciphergame.dek.service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.nycu.ce.ciphergame.dek.entity.Dek;
+import com.nycu.ce.ciphergame.dek.entity.id.DekId;
+import com.nycu.ce.ciphergame.dek.entity.id.UserId;
+import com.nycu.ce.ciphergame.dek.repository.DekRepository;
+
+@Service
+public class DekService {
+
+    @Autowired
+    private DekRepository dekRepository;
+
+    public List<Dek> getDeks(UserId userId, List<DekId> dekIds) {
+        List<UUID> ids = dekIds.stream()
+                .map(DekId::toUUID)
+                .collect(Collectors.toList());
+        return dekRepository.findAllOwnerIdAndIdIn(userId.toUUID(), ids);
+    }
+
+    public List<Dek> storeDeks(List<Dek> newDeks) {
+
+        dekRepository.saveAll(newDeks);
+        return newDeks;
+    }
+}

--- a/dek/src/main/java/com/nycu/ce/ciphergame/dek/swagger/SwaggerConfig.java
+++ b/dek/src/main/java/com/nycu/ce/ciphergame/dek/swagger/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.nycu.ce.ciphergame.dek.swagger;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+@Profile("!prod") // This ensures Swagger is only active in non-prod environments
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("CipherGame Dek API")
+                        .version("1.0")
+                        .description("API documentation for JWT-secured endpoints"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .name(securitySchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public GroupedOpenApi publicApi() {
+        return GroupedOpenApi.builder()
+                .group("public")
+                .pathsToMatch("/**")
+                .build();
+    }
+}

--- a/dek/src/main/resources/application.properties
+++ b/dek/src/main/resources/application.properties
@@ -1,1 +1,17 @@
 spring.application.name=dek
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Hibernate SQL and parameter logging
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+logging.level.org.hibernate.orm.jdbc.bind=TRACE
+logging.level.org.hibernate.orm.jdbc.extract=TRACE
+logging.level.org.hibernate.type.descriptor=TRACE
+
+# JWT Configuration
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${JWT_ISSUER_URI}

--- a/dek/src/main/resources/application.properties
+++ b/dek/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=dek

--- a/dek/src/test/java/com/nycu/ce/ciphergame/dek/DekApplicationTests.java
+++ b/dek/src/test/java/com/nycu/ce/ciphergame/dek/DekApplicationTests.java
@@ -1,0 +1,13 @@
+package com.nycu.ce.ciphergame.dek;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DekApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/docker-compose.dek.dev.yml
+++ b/docker-compose.dek.dev.yml
@@ -1,21 +1,23 @@
 version: '3.9'
 
 services:
-  backend:
-    ports:
-      - "8080:8080"
-  dek:
-    ports:
-      - "8082:8082"
 
-  auth-server:
+  dek:
     entrypoint: []
     command: "./mvnw spring-boot:run -Dspring-boot.run.arguments=--logging.level.org.springframework.security=DEBUG"
     ports:
-      - "8081:8081"
+      - "8082:8082"
     working_dir: /app
     volumes:
-      - ./auth:/app
+      - ./dek:/app
       - ~/.m2:/root/.m2
     environment:
       - SPRING_PROFILES_ACTIVE=dev
+
+  backend:
+    ports:
+      - "8080:8080"
+
+  auth-server:
+    ports:
+      - "8081:8081"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,6 +28,18 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
 
+  dek:
+    entrypoint: []
+    command: "./mvnw spring-boot:run -Dspring-boot.run.arguments=--logging.level.org.springframework.security=DEBUG"
+    ports:
+      - "8082:8082"
+    working_dir: /app
+    volumes:
+      - ./dek:/app
+      - ~/.m2:/root/.m2
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+
   auth-server:
     entrypoint: []
     command: "./mvnw spring-boot:run -Dspring-boot.run.arguments=--logging.level.org.springframework.security=DEBUG"

--- a/docker-compose.frontend.dev.yml
+++ b/docker-compose.frontend.dev.yml
@@ -19,6 +19,9 @@ services:
   backend:
     ports:
       - "8080:8080"
+  dek:
+    ports:
+      - "8082:8082"
       
   auth-server:
     ports:

--- a/docker-compose.kms.dev.yml
+++ b/docker-compose.kms.dev.yml
@@ -4,6 +4,9 @@ services:
   backend:
     ports:
       - "8080:8080"
+  dek:
+    ports:
+      - "8082:8082"
       
   auth-server:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,21 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${BACKEND_PASSWORD}
       - JWT_ISSUER_URI=${JWT_ISSUER_URI}
 
+  dek:
+    container_name: dek
+    build: ./dek
+    expose:
+      - "8082"
+    depends_on:
+      - db
+    environment:
+      - SERVER_PORT=8082
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATASOURCE_URL=${DEK_DB_URL}
+      - SPRING_DATASOURCE_USERNAME=${DEK_USER}
+      - SPRING_DATASOURCE_PASSWORD=${DEK_PASSWORD}
+      - JWT_ISSUER_URI=${JWT_ISSUER_URI}
+
   auth-server:
     container_name: auth-server
     build: ./auth

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -79,6 +79,15 @@ BEGIN
 END
 \$\$;
 
+-- Create dek role if not exists
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${DEK_USER}') THEN
+    CREATE ROLE ${DEK_USER} WITH LOGIN PASSWORD '${DEK_PASSWORD}';
+  END IF;
+END
+\$\$;
+
 -- Create Auth Server role if not exists
 DO \$\$
 BEGIN
@@ -108,6 +117,9 @@ GRANT SELECT, UPDATE ON users_backend_view TO ${BACKEND_USER};
 -- Grant SELECT, INSERT on the backend_audit_log
 GRANT SELECT, INSERT on backend_audit_log TO ${BACKEND_USER};
 GRANT USAGE, SELECT ON SEQUENCE backend_audit_log_id_seq TO ${BACKEND_USER};
+
+-- Grant SELECT, INSERT, UPDATE on the dek
+GRANT SELECT, INSERT, UPDATE on encrypted_deks TO ${DEK_USER};
 
 -- Auth Server
 GRANT SELECT, INSERT, UPDATE ON users, encrypted_deks TO ${AUTH_USER};

--- a/scripts/init-schema.sql
+++ b/scripts/init-schema.sql
@@ -39,8 +39,7 @@ CREATE TABLE IF NOT EXISTS group_members (
 -- EncryptedDEKs Table
 CREATE TABLE IF NOT EXISTS encrypted_deks (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    owner_id UUID REFERENCES users(id),
-    entity_id UUID NOT NULL,
+    owner_id UUID NOT NULL,
     cmk_version INTEGER NOT NULL CHECK (cmk_version >= 1),
     encrypted_dek TEXT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT now()


### PR DESCRIPTION
## Summary

This pull request adds two new endpoints to the `DekController` to manage Data Encryption Keys (DEKs):

- `GET /deks`: Retrieve DEKs by a list of UUIDs.
- `POST /deks`: Store new DEKs with associated `ownerId`.

## Features

### ✅ `GET /deks`

- Accepts a JSON payload with a required `dekIds` array of UUIDs (max 100).
- Returns a list of DEK objects that match the provided UUIDs.

**Request Example**:
```json
{
  "dekIds": ["8f4eec42-f0a4-4a21-9960-a33c4af80e2a"]
}
```

**Response Example**:
```json
[
  {
    "id": "8f4eec42-f0a4-4a21-9960-a33c4af80e2a",
    "dek": "string"
  }
]
```

### ✅ `POST /deks`

- Accepts a JSON array of DEK creation requests.
- Each object must include `ownerId` (UUID) and `dek` (string).
- Returns a list of created DEK objects with their assigned UUIDs.

**Request Example**:
```json
[
  {
    "ownerId": "b3742f27-4371-4a67-9b7b-65a7b05a4b12",
    "dek": "string"
  }
]
```

**Response Example**:
```json
[
  {
    "id": "8f4eec42-f0a4-4a21-9960-a33c4af80e2a",
    "dek": "string"
  }
]
```

## Notes

- Input validation is enforced using `@NotEmpty` and `@Size(max = 100)` on `dekIds`.
- All endpoints require JWT authentication.
- Adheres to the structure defined in the OpenAPI 3.0 spec.

## Checklist

- [x] Controller methods implemented
- [x] Request and response DTOs defined
- [x] Input validation added
- [x] Swagger documentation verified